### PR TITLE
Fix: missing Jupiter and wrong LicheeRV info

### DIFF
--- a/LicheeRV_Nano/README.md
+++ b/LicheeRV_Nano/README.md
@@ -13,15 +13,15 @@
 
 ### Hardware Information
 
-- Milk-V Duo S (256M, SG2002)
+- LicheeRV Nano (SG2002)
 
 ## Test Results
 
-| Software Category | Package Name | Test Results (Test Report)     |
-|-------------------|--------------|--------------------------------|
-| BuildRoot Image   | N/A          | [Basic][BuildRoot]             |
-| FreeRTOS Startup  | N/A          | [Basic][FreeRTOS]              |
-| Debian Image      | N/A          | [Basic][Debian]                |
+| Software Category | Package Name | Test Results (Test Report) |
+| ----------------- | ------------ | -------------------------- |
+| BuildRoot Image   | N/A          | [Basic][BuildRoot]         |
+| FreeRTOS Startup  | N/A          | [Basic][FreeRTOS]          |
+| Debian Image      | N/A          | [Basic][Debian]            |
 
 [BuildRoot]: ./BuildRoot/README.md
 [FreeRTOS]: ./FreeRTOS/README.md

--- a/LicheeRV_Nano/README_zh.md
+++ b/LicheeRV_Nano/README_zh.md
@@ -13,15 +13,15 @@
 
 ### 硬件开发板信息
 
-- Milk-V Duo S (256M, SG2002)
+- LicheeRV Nano (SG2002)
 
 ## 测试结果
 
 | 软件分类           | 软件包名 | 测试结果（测试报告） |
-|------------------|----------|--------------------|
-| BuildRoot 镜像启动 | N/A      | [Basic][BuildRoot] |
-| FreeRTOS 启动      | N/A      | [Basic][FreeRTOS]  |
-| Debian 镜像启动    | N/A      | [Basic][Debian]    |
+| ------------------ | -------- | -------------------- |
+| BuildRoot 镜像启动 | N/A      | [Basic][BuildRoot]   |
+| FreeRTOS 启动      | N/A      | [Basic][FreeRTOS]    |
+| Debian 镜像启动    | N/A      | [Basic][Debian]      |
 
 [BuildRoot]: ./BuildRoot/README_zh.md
 [FreeRTOS]: ./FreeRTOS/README_zh.md

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 | SG2002            | XuanTie C906 + ARM Cortex-A53              | [LicheeRV Nano][LicheeRVNano]           | -          | Basic         | -      | -      | -          | -           | -         | -         | -        | -      | -          | -       | Basic     | -       | -      | -      | -     | -      |
 | BL808             | XuanTie C906 + XuanTie E907 + XuanTie E902 | [Sipeed M1s Dock][SipeedM1s]            | -          | -             | -      | -      | -          | -           | -         | -         | -        | -      | -          | -       | Basic     | -       | -      | -      | -     | -      |
 | Keystone K1       | SpacemiT X60                               | [BananaPi BPI-F3][BPI-F3]               | -          | -             | -      | -      | -          | -           | -         | -         | -        | -      | -          | Basic   | -         | -       | Basic  | -      | -     | -      |
+| Keystone K1       | SpacemiT X60                               | [Milk-V Jupiter][Jupiter]               | -          | -             | CFT    | -      | -          | -           | -         | -         | -        | CFT    | -          | -       | -         | -       | CFT    | -      | -     | -      |
 | TH1520            | XuanTie C910 + XuanTie C906 + XuanTie E902 | [BeagleV-Ahead]                         | -          | -             | -      | -      | -          | -           | -         | -         | -        | CFT    | -          | -       | -         | -       | -      | -      | CFT   | -      |
 | MPFS025T          | SiFive U54 + SiFive E51                    | [BeagleV-Fire]                          | -          | -             | -      | -      | -          | -           | -         | -         | -        | CFT    | -          | -       | -         | -       | -      | -      | -     | -      |
 | JH7110            | SiFive U74 + SiFive S7 + SiFive E24        | [Star64]                                | CFT        | CFT           | -      | CFT    | -          | -           | CFT       | CFT       | CFT      | CFT    | -          | CFT     | CFT       | CFT     | -      | CFT    | CFT   | -      |
@@ -139,7 +140,7 @@
 [C906]: ./D1_LicheeRV/README.md
 [Unmatched]: ./Unmatched/README.md
 [DuoS]: ./Duo_S/README.md
-[Mars]: ./Mars/README.md
+[Mars]: ./Mars/README.mdJupiter
 [Vega]: ./Vega/README.md
 [Meles]: ./Meles/README.md
 [MaixBit]: ./Maix-I_K210/README.md
@@ -174,6 +175,7 @@
 [mangopi_mq]: ./mangopi_mq/README.md
 [NeZha-D1s]: ./NeZha-D1s/README.md
 [BPI-F3]: ./BPI-F3/README.md
+[Jupiter]: ./Jupiter/README.md
 [BeagleV-Ahead]: ./BeagleV-Ahead/README.md
 [BeagleV-Fire]: ./BeagleV-Fire/README.md
 [STAR64]: ./STAR64/README.md

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@
 
 
 | CPU         | IP Core                                    | Product/Model                          | Android | OpenHarmony |
-|-------------|--------------------------------------------|----------------------------------------|---------|-------------|
+| ----------- | ------------------------------------------ | -------------------------------------- | ------- | ----------- |
 | JH7100      | SiFive U74 + SiFive E24                    | [VisionFive][VF1]                      | WIP     | WIP         |
 | JH7110      | SiFive U74 + SiFive S7 + SiFive E24        | [VisionFive 2][VF2]                    | WIP     | WIP         |
 | D1-H        | XuanTie C906                               | [LicheeRV/AWOL Nezha][C906]            | -       | CFT         |
@@ -140,7 +140,7 @@
 [C906]: ./D1_LicheeRV/README.md
 [Unmatched]: ./Unmatched/README.md
 [DuoS]: ./Duo_S/README.md
-[Mars]: ./Mars/README.mdJupiter
+[Mars]: ./Mars/README.md
 [Vega]: ./Vega/README.md
 [Meles]: ./Meles/README.md
 [MaixBit]: ./Maix-I_K210/README.md

--- a/README_zh.md
+++ b/README_zh.md
@@ -31,6 +31,7 @@
 | SG2002            | XuanTie C906 + ARM Cortex-A53              | [LicheeRV Nano][LicheeRVNano]           | -          | Basic         | -      | -      | -          | -           | -         | -         | -        | -      | -          | -       | Basic     | -       | -      | -      | -     | -      |
 | BL808             | XuanTie C906 + XuanTie E907 + XuanTie E902 | [Sipeed M1s Dock][SipeedM1s]            | -          | -             | -      | -      | -          | -           | -         | -         | -        | -      | -          | -       | Basic     | -       | -      | -      | -     | -      |
 | Keystone K1       | SpacemiT X60                               | [BananaPi BPI-F3][BPI-F3]               | -          | -             | -      | -      | -          | -           | -         | -         | -        | -      | -          | Basic   | -         | -       | Basic  | -      | -     | -      |
+| Keystone K1       | SpacemiT X60                               | [Milk-V Jupiter][Jupiter]               | -          | -             | CFT    | -      | -          | -           | -         | -         | -        | CFT    | -          | -       | -         | -       | CFT    | -      | -     | -      |
 | TH1520            | XuanTie C910 + XuanTie C906 + XuanTie E902 | [BeagleV-Ahead]                         | -          | -             | -      | -      | -          | -           | -         | -         | -        | CFT    | -          | -       | -         | -       | -      | -      | CFT   | -      |
 | MPFS025T          | SiFive U54 + SiFive E51                    | [BeagleV-Fire]                          | -          | -             | -      | -      | -          | -           | -         | -         | -        | CFT    | -          | -       | -         | -       | -      | -      | -     | -      |
 | JH7110            | SiFive U74 + SiFive S7 + SiFive E24        | [Star64]                                | CFT        | CFT           | -      | CFT    | -          | -           | CFT       | CFT       | CFT      | CFT    | -          | CFT     | CFT       | CFT     | -      | CFT    | CFT   | -      |
@@ -174,6 +175,7 @@
 [mangopi_mq]: ./mangopi_mq/README_zh.md
 [NeZha-D1s]: ./NeZha-D1s/README_zh.md
 [BPI-F3]: ./BPI-F3/README_zh.md
+[Jupiter]: ./Jupiter/README_zh.md
 [BeagleV-Ahead]: ./BeagleV-Ahead/README_zh.md
 [BeagleV-Fire]: ./BeagleV-Fire/README_zh.md
 [STAR64]: ./STAR64/README_zh.md


### PR DESCRIPTION
- Add missing Milk-V Jupiter entry in support matrix
- Fix incorrect "Duo 256M" info in LicheeRV Nano's docs